### PR TITLE
Create jquery.read-more.js

### DIFF
--- a/jquery.read-more.js
+++ b/jquery.read-more.js
@@ -1,0 +1,24 @@
+function hideContent () {
+  $(".js-product_section .description").contents().slice( 10).wrapAll( '<span class="more-text"></span>' );
+  $($.parseHTML('<a href="javascript:void(0);" class="read-more"><br>Read more...</a> ')).insertBefore(".more-text");
+  unhideContent();
+}
+
+function unhideContent () {
+  $(".read-more").click(function(){
+    $(this).siblings(".more-text").contents().unwrap();
+    $($.parseHTML('<a href="javascript:void(0);" class="read-less"><br>Read less...</a> ')).appendTo(".description");
+    $(this).remove();
+
+    $(".read-less").on('click', function() {
+	  $(this).remove();
+      hideContent();
+    });
+  });
+}
+
+$(document).ready(function(){
+
+  hideContent();
+
+});


### PR DESCRIPTION
Goal: Add Read more/Read less link to the product description on Shopify.
What I found from Google Search is a text only approach but that doesn't fit my problem.
Here I used the number of DOM elements instead of the number of text characters.